### PR TITLE
add exportHtml option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ require("!ngtemplate?relativeTo=/projects/test/app!html!file.html");
 // angular.module('ng').run(['$templateCache', function(c) { c.put('file.html', "<file.html processed by html-loader>") }]);
 ```
 
+ngTemplate loader can also be used to export content the HTML file if `exportHtml` is set to `true`, so you can use require directly AngularJS with template parameters e.g. 
+
+``` javascript
+var templateContent = require('ngtemplate?exportHtml=true!html!./test.html');
+
+app.directive('testDirective', function() {
+    return {
+        restrict: 'E',
+        template: templateContent
+    }
+});
+```
+
 ### RelativeTo and Prefix
 
 You can set the base path of your templates using `relativeTo` and `prefix` parameters. `relativeTo` is used

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function (content) {
     var query = loaderUtils.parseQuery(this.query);
     var ngModule = query.module || 'ng'; // ng is the global angular module that does not need to explicitly required
     var relativeTo = query.relativeTo || '';
-    var exportHtml = query.exportHtml === "true";
+    var exportHtml = query.exportHtml === "true" || query.exportHtml === true;
     var prefix = query.prefix || '';
     var absolute = false;
     var pathSep = query.pathSep || '/';

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = function (content) {
     var query = loaderUtils.parseQuery(this.query);
     var ngModule = query.module || 'ng'; // ng is the global angular module that does not need to explicitly required
     var relativeTo = query.relativeTo || '';
+    var exportHtml = query.exportHtml === "true";
     var prefix = query.prefix || '';
     var absolute = false;
     var pathSep = query.pathSep || '/';
@@ -49,8 +50,9 @@ module.exports = function (content) {
     }
 
     return "var path = '"+jsesc(filePath)+"';\n" +
-        "window.angular.module('" + ngModule + "').run(['$templateCache', function(c) { c.put(path, " + html + ") }]);\n" +
-        "module.exports = path;";
+        "var html = " + html + ";\n" + 
+        "window.angular.module('" + ngModule + "').run(['$templateCache', function(c) { c.put(path, html) }]);\n" +
+        "module.exports = " + (exportHtml ? "html" : "path") + ";";
 
     function findQuote(content, backwards) {
         var i = backwards ? content.length - 1 : 0;


### PR DESCRIPTION
Add a options called  exportHtml   ,  if set to true,  the loader will export  html template instead of  path . 

In case  of layzing loading ,   angular.module('ng').run block will not execute ,    templateUrl: ''xxxx"  will not work ,  but  template = require('ngtemplate?exportHtml=true')   works . 

