### PR TITLE
Implement proper chained loading using module.exports instead of stri…

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,31 +38,11 @@ module.exports = function (content) {
     }
 
     var filePath = prefix + resource.slice(relativeToIndex + relativeTo.length); // get the base path
-    var html;
 
-    if (content.match(/^module\.exports/)) {
-        var firstQuote = findQuote(content, false);
-        var secondQuote = findQuote(content, true);
-        html = content.substr(firstQuote, secondQuote - firstQuote + 1);
-    } else {
-        html = content;
-    }
-
-    return "var path = '"+jsesc(filePath)+"';\n" +
-        "var html = " + html + ";\n" +
+    return content + "\n\nvar path = '"+jsesc(filePath)+"';\n" +
+        "var html = module.exports;\n" +
         "window.angular.module('" + ngModule + "').run(['$templateCache', function(c) { c.put(path, html) }]);\n" +
         "module.exports = path;";
-
-    function findQuote(content, backwards) {
-        var i = backwards ? content.length - 1 : 0;
-        while (i >= 0 && i < content.length) {
-            if (content[i] == '"' || content[i] == "'") {
-                return i;
-            }
-            i += backwards ? -1 : 1;
-        }
-        return -1;
-    }
 
     // source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Using_Special_Characters
     function escapeRegExp(string) {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,11 @@
     "loader-utils": "~0.2.6"
   },
   "devDependencies": {
+    "apply-loader": "^0.1.0",
     "baggage-loader": "^0.2.1",
     "html-loader": "^0.2.2",
+    "jade": "^1.11.0",
+    "jade-loader": "^0.7.1",
     "raw-loader": "^0.5.1",
     "webpack": "^1.7.0"
   }

--- a/test/src/entry.js
+++ b/test/src/entry.js
@@ -18,3 +18,5 @@ console.log(require('../../index.js?relativeTo=/' + __dirname + '/!html-loader!.
 console.log(require('../../index.js?prefix=/prefix!html-loader!./test.html'));
 console.log(require('../../index.js?prefix=/prefix/&relativeTo=/' + __dirname + '/!html-loader!./test.html'));
 console.log(require('../../index.js?pathSep=\\&prefix=\\prefix\\&relativeTo=' + __dirname + '\\!html-loader!.\\test.html'));
+console.log(require('../../index.js?prefix=/prefix/&relativeTo=/' + __dirname + '/!html-loader!./test.html'));
+console.log(require('../../index.js!apply-loader!jade-loader!./test.jade'));


### PR DESCRIPTION
…ng magic

I am trying to use jade templates as partials and I simply couldn't get it to run.

the jade loader is returning a function and I am picking it up, create the final template string by piping it through apply and then I want to pipe the result to ngtemplate.

This is the result:

```
ERROR in .!./~/apply-loader!./~/jade-loader!./test/src/test.jade
Module parse failed: /Users/mop/projects/ngtemplate-loader/index.js!/Users/mop/projects/ngtemplate-loader/node_modules/apply-loader/index.js!/Users/mop/projects/ngtemplate-loader/node_modules/jade-loader/index.js!/Users/mop/projects/ngtemplate-loader/test/src/test.jade Line 2: Unexpected token var
You may need an appropriate loader to handle this file type.
| var path = '/Users/mop/projects/ngtemplate-loader/test/src/test.jade';
| var html = var jade = require("/Users/mop/projects/ngtemplate-loader/node_modules/jade/lib/runtime.js");
| 
| module.exports = function template(locals) {
```

After digging into the code I stumpled upon the string magic (/module\.exports/) in this module. I am a total newbie to webpack but this doesn't seem to be the correct way to do it.

I had a look here:

https://github.com/mogelbrod/apply-loader/blob/master/index.js

and this seems to be a solid way to properly chain loaders.
