### PR TITLE
Use webpack `require()` to get angular reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ require('!ngtemplate?module=myTemplates&relativeTo=/projects/test/app!html!file.
 
  Make sure you use the same path separator for the `prefix` and `relativeTo` parameters, all templateUrls and in your webpack.config.js file.
 
+### Using with npm requires
+
+This module relies on angular being available on `window` object. However, in cases angular is connected from `node_modules` via `require('angular')`, option to force this module to get the angular should be used:
+
+```javascript
+require('!ngtemplate?requireAngular!html!file.html');
+
+// => generates the javascript:
+// var angular = require('angular');
+// angular.module('ng').run(['$templateCache', function(c) { c.put('file.html', '<file.html processed by html-loader>') }]);
+```
+
 ## Webpack Config
 
 It's recommended to adjust your `webpack.config` so `ngtemplate!html!` is applied automatically on all files ending on `.html`:

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = function (content) {
     var ngModule = query.module || 'ng'; // ng is the global angular module that does not need to explicitly required
     var relativeTo = query.relativeTo || '';
     var prefix = query.prefix || '';
+    var requireAngular = !!query.requireAngular || false;
     var absolute = false;
     var pathSep = query.pathSep || '/';
     var resource = this.resource;
@@ -50,7 +51,8 @@ module.exports = function (content) {
 
     return "var path = '"+jsesc(filePath)+"';\n" +
         "var html = " + html + ";\n" +
-        "window.angular.module('" + ngModule + "').run(['$templateCache', function(c) { c.put(path, html) }]);\n" +
+        (requireAngular ? "var angular = require('angular');\n" : "window.") +
+        "angular.module('" + ngModule + "').run(['$templateCache', function(c) { c.put(path, html) }]);\n" +
         "module.exports = path;";
 
     function findQuote(content, backwards) {


### PR DESCRIPTION
In some cases, dependencies are managed by webpack, and therefore there
is no reference to angular on 'window' object. So in those cases this
library was breaking the build.

This fix enables the option to require angular in cases when it is needed