### PR TITLE
Throw a new Error instance instead of a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function (content) {
 
     var relativeToIndex = resource.indexOf(relativeTo);
     if (relativeToIndex === -1 || (absolute && relativeToIndex !== 0)) {
-        throw 'The path for file doesn\'t contain relativeTo param';
+        throw new Error('The path for file doesn\'t contain relativeTo param');
     }
 
     var filePath = prefix + resource.slice(relativeToIndex + relativeTo.length); // get the base path


### PR DESCRIPTION
When you throw a string it does not show up in the error output for webpack. (tested with node v6.5.0)

Fixes #56