### PR TITLE
Export as harmony module

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,11 +53,11 @@ module.exports = function (content) {
         html = content;
     }
 
-    return "var path = '"+jsesc(filePath)+"';\n" +
+    return (requireAngular ? 'import angular from "angular";\n' : 'var angular = window.angular;\n') +
+        "var path = '"+jsesc(filePath)+"';\n" +
         "var html = " + html + ";\n" +
-        (requireAngular ? "var angular = require('angular');\n" : "window.") +
         "angular.module('" + ngModule + "').run(['$templateCache', function(c) { c.put(path, html) }]);\n" +
-        "module.exports = path;";
+        "export default path;";
 
     function getAndInterpolateOption(optionKey, def) {
         return options[optionKey]


### PR DESCRIPTION
With Webpack 3 we can now take advantage of ModuleConcatenationPlugin but only for harmony modules: https://github.com/webpack/webpack/blob/master/lib/optimize/ModuleConcatenationPlugin.js#L42

To take full advantage of this (and it really makes a big difference on bootstrap) we need ngtemplates-loader to output harmony modules too.

I'm new to webpack so sorry in advance for anything in the code!