### PR TITLE
Async load to $templateCache(webpack codesplitting)

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = function (content) {
     var relativeTo = getAndInterpolateOption.call(this, 'relativeTo', '');
     var prefix = getAndInterpolateOption.call(this, 'prefix', '');
     var requireAngular = !!options.requireAngular || false;
+    var async = !!options.async || false;
     var absolute = false;
     var pathSep = options.pathSep || '/';
     var resource = this.resource;
@@ -55,8 +56,11 @@ module.exports = function (content) {
 
     return "var path = '"+jsesc(filePath)+"';\n" +
         "var html = " + html + ";\n" +
-        (requireAngular ? "var angular = require('angular');\n" : "window.") +
-        "angular.module('" + ngModule + "').run(['$templateCache', function(c) { c.put(path, html) }]);\n" +
+        (requireAngular ? "var angular = require('angular');\n" : "") +
+        (async ? "var inj=window.angular.element(window.document).injector();\n" +
+            "if(inj){inj.get('$templateCache').put(path,html);} else {\n" : "") +
+        "window.angular.module('" + ngModule + "').run(['$templateCache', function(c) { c.put(path, html) }]);" +
+        (async ? "}" : "") + "\n" +
         "module.exports = path;";
 
     function getAndInterpolateOption(optionKey, def) {


### PR DESCRIPTION
ISSUE: when you use webpack codesplitting we have error with loader - because it attached event to the .run method of the module what fired once on init.
So when came second js(our module is already init)  file with templates it didn't write to the $templateCache and throw error like it doesn't exist.