### PR TITLE
Add support for parent directories in the relativeTo parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function (content) {
 
     var relativeToIndex = resource.indexOf(relativeTo);
     if (relativeToIndex === -1 || (absolute && relativeToIndex !== 0)) {
-        throw new Error('The path for file doesn\'t contain relativeTo param');
+        throw new Error('The path for file "' + resource + '" doesn\'t contain relativeTo param "' + relativeTo + '".');
     }
 
     // a custom join of prefix using the custom path sep

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function (content) {
 
     var options = loaderUtils.getOptions(this) || {};
     var ngModule = getAndInterpolateOption.call(this, 'module', 'ng'); // ng is the global angular module that does not need to explicitly required
-    var relativeTo = getAndInterpolateOption.call(this, 'relativeTo', '');
+    var relativeTo = path.normalize(getAndInterpolateOption.call(this, 'relativeTo', ''));
     var prefix = getAndInterpolateOption.call(this, 'prefix', '');
     var requireAngular = !!options.requireAngular || false;
     var absolute = false;

--- a/test/src/entry.js
+++ b/test/src/entry.js
@@ -15,6 +15,7 @@ console.log(require('../../index.js?relativeTo=/test/src/!html-loader!./test.htm
 console.log(require('../../index.js?relativeTo=src/!html-loader!./test.html'));
 console.log(require('../../index.js?relativeTo=' + __dirname + '/!html-loader!./test.html'));
 console.log(require('../../index.js?relativeTo=/' + __dirname + '/!html-loader!./test.html'));
+console.log(require('../../index.js?relativeTo=' + __dirname + '/../!html-loader!./test.html'));
 console.log(require('../../index.js?prefix=/prefix!html-loader!./test.html'));
 console.log(require('../../index.js?prefix=/prefix/&relativeTo=/' + __dirname + '/!html-loader!./test.html'));
 console.log(require('../../index.js?module=[name]&prefix=[folder]&relativeTo=[path]!html-loader!./test.html'));


### PR DESCRIPTION
`npm run test` runs successfully, is that all that is needed? I couldn't figure out where to put an assertion about the resulting template path in the cache.